### PR TITLE
Finalize the syntax of sig, prb and drv

### DIFF
--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -62,17 +62,17 @@ def LLHD_SigOp : LLHD_Op<"sig",
        **Custom syntax:**
 
        ```
-       sig-op ::= ssa-id `=` `llhd.sig` sig-name ssa-init attr-dict `:` init-type `->` !llhd.sig<init-type>
+       sig-op ::= ssa-id `=` `llhd.sig` sig-name ssa-init attr-dict `:` init-type
        ```
 
        **Examples:**
 
        ```
        %init_i64 = llhd.const 123 : i64
-       %sig_i64 = llhd.sig "foo" %init_64 : i64 -> !llhd.sig<i64>
+       %sig_i64 = llhd.sig "foo" %init_64 : i64
 
        %init_i1 = llhd.const 1 : i1
-       %sig_i1 = llhd.sig "bar" %init_i1 : i1 -> !llhd.sig<i1>
+       %sig_i1 = llhd.sig "bar" %init_i1 : i1
        ```
        The first `llhd.sig` instruction creates a new signal named "foo", carrying an `i64`
        type with initial value of 123, while the second one creates a new signal
@@ -82,7 +82,7 @@ def LLHD_SigOp : LLHD_Op<"sig",
     let arguments = (ins StrAttr:$name, AnySignlessInteger:$init);
     let results = (outs LLHD_AnySigType:$result);
 
-    let assemblyFormat = "$name $init attr-dict `:` type($init) `->` type($result)";
+    let assemblyFormat = "$name $init attr-dict `:` type($init)";
 }
 
 def LLHD_PrbOp : LLHD_Op<"prb",
@@ -100,22 +100,22 @@ def LLHD_PrbOp : LLHD_Op<"prb",
         **Custom syntax:**
 
         ```
-        prb-op ::= ssa-id `=` `llhd.prb` ssa-sig attr-dict `:` !llhd.sig<type> `->` type
+        prb-op ::= ssa-id `=` `llhd.prb` ssa-sig attr-dict `:` !llhd.sig<type>
         ```
 
         **Examples:***
 
         ```
         %const_i1 = llhd.const 1 : i1
-        %sig_i1 = llhd.sig %const_i1 : i1 -> !llhd.sig<i1>
-        %prbd = llhd.prb %sig_i1 : !llhd.sig<i1> -> i1
+        %sig_i1 = llhd.sig %const_i1 : i1
+        %prbd = llhd.prb %sig_i1 : !llhd.sig<i1>
         ```
     }];
 
     let arguments = (ins LLHD_AnySigType:$signal);
     let results = (outs AnySignlessInteger:$result);
 
-    let assemblyFormat = "$signal attr-dict `:` type($signal) `->` type($result)";
+    let assemblyFormat = "$signal attr-dict `:` type($signal)";
 }
 
 def LLHD_DrvOp : LLHD_Op<"drv",
@@ -135,7 +135,7 @@ def LLHD_DrvOp : LLHD_Op<"drv",
         **Custom Syntax:**
 
         ```
-        drv-op ::= `llhd.drv` ssa-signal `,` ssa-const `,` ssa-time `,` ssa-enable `:` !llhd.sig<const-type> `,` const-type `,` time-type `,` i1
+        drv-op ::= `llhd.drv` ssa-signal `,` ssa-const `after` ssa-time (`if` ssa-enable)? `:` !llhd.sig<const-type>
         ```
 
         **Examples:**
@@ -144,11 +144,11 @@ def LLHD_DrvOp : LLHD_Op<"drv",
         %init = llhd.const 1 : i1
         %en = llhd.const 0 : i1
         %time = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-        %sig = llhd.sig %init : i1 -> !llhd.sig<i1>
+        %sig = llhd.sig %init : i1
         %new = llhd.not %init : i1
 
-        llhd.drv %sig, %new, %time : !llhd.sig<i1>, i1, !llhd.time
-        llhd.drv %sig, %new, %time, %en : !llhd.sig<i1>, i1, !llhd.time, i1
+        llhd.drv %sig, %new after %time : !llhd.sig<i1>
+        llhd.drv %sig, %new after %time if %en : !llhd.sig<i1>
         ```
     }];
 
@@ -157,7 +157,9 @@ def LLHD_DrvOp : LLHD_Op<"drv",
                          LLHD_TimeType:$time,
                          Optional<I1>:$enable);
 
-    let assemblyFormat = "operands attr-dict `:` type(operands)";
+    let assemblyFormat = [{
+        $signal `,` $value `after` $time ( `if` $enable^ )? attr-dict `:` type($signal)
+    }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/LLHD/enity.mlir
+++ b/test/Dialect/LLHD/enity.mlir
@@ -8,7 +8,7 @@
     // CHECK-NEXT: %[[C0:.*]] = llhd.const 1
     %0 = llhd.const 1 : i64
     // CHECK-NEXT: %[[P0:.*]] = llhd.prb %[[ARG0]]
-    %1 = llhd.prb %arg0 : !llhd.sig<i64> -> i64
+    %1 = llhd.prb %arg0 : !llhd.sig<i64>
     "llhd.terminator"() {} : () -> ()
 // CHECK-NEXT: }
 }) {sym_name="foo", ins=2, type=(!llhd.sig<i64>, !llhd.sig<i64>, !llhd.sig<i64>)->()} : () -> ()

--- a/test/Dialect/LLHD/sig.mlir
+++ b/test/Dialect/LLHD/sig.mlir
@@ -3,11 +3,11 @@
 llhd.entity @check_sig_inst () -> () {
     // CHECK: %[[CI1:.*]] = llhd.const
     %cI1 = llhd.const 0 : i1
-    // CHECK-NEXT: %{{.*}} = llhd.sig "sigI1" %[[CI1]] : i1 -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.sig "sigI1" %[[CI1]] : i1
     %sigI1 = "llhd.sig"(%cI1) {name = "sigI1"} : (i1) -> !llhd.sig<i1>
     // CHECK-NEXT: %[[CI64:.*]] = llhd.const
     %cI64 = llhd.const 0 : i64
-    // CHECK-NEXT: %{{.*}} = llhd.sig "sigI64" %[[CI64]] : i64 -> !llhd.sig<i64>
+    // CHECK-NEXT: %{{.*}} = llhd.sig "sigI64" %[[CI64]] : i64
     %sigI64 = "llhd.sig"(%cI64) {name = "sigI64"} : (i64) -> !llhd.sig<i64>
 }
 
@@ -15,9 +15,9 @@ llhd.entity @check_sig_inst () -> () {
 // CHECK-SAME: %[[SI1:.*]]: !llhd.sig<i1>
 // CHECK-SAME: %[[SI64:.*]]: !llhd.sig<i64>
 func @check_prb(%sigI1 : !llhd.sig<i1>, %sigI64 : !llhd.sig<i64>) {
-    // CHECK: %{{.*}} = llhd.prb %[[SI1]] : !llhd.sig<i1> -> i1
+    // CHECK: %{{.*}} = llhd.prb %[[SI1]] : !llhd.sig<i1>
     %0 = "llhd.prb"(%sigI1) {} : (!llhd.sig<i1>) -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.prb %[[SI64]] : !llhd.sig<i64> -> i64
+    // CHECK-NEXT: %{{.*}} = llhd.prb %[[SI64]] : !llhd.sig<i64>
     %1 = "llhd.prb"(%sigI64) {} : (!llhd.sig<i64>) -> i64
 
     return
@@ -30,11 +30,11 @@ func @check_prb(%sigI1 : !llhd.sig<i1>, %sigI64 : !llhd.sig<i64>) {
 // CHECK-SAME: %[[CI64:.*]]: i64
 // CHECK-SAME: %[[TIME:.*]]: !llhd.time
 func @check_drv(%sigI1 : !llhd.sig<i1>, %sigI64 : !llhd.sig<i64>, %cI1 : i1, %cI64 : i64, %t : !llhd.time) {
-    // CHECK-NEXT: llhd.drv %[[SI1]], %[[CI1]], %[[TIME]] : !llhd.sig<i1>, i1, !llhd.time
+    // CHECK-NEXT: llhd.drv %[[SI1]], %[[CI1]] after %[[TIME]] : !llhd.sig<i1>
     "llhd.drv"(%sigI1, %cI1, %t) {} : (!llhd.sig<i1>, i1, !llhd.time) -> ()
-    // CHECK-NEXT: llhd.drv %[[SI64]], %[[CI64]], %[[TIME]] : !llhd.sig<i64>, i64, !llhd.time
+    // CHECK-NEXT: llhd.drv %[[SI64]], %[[CI64]] after %[[TIME]] : !llhd.sig<i64>
     "llhd.drv" (%sigI64, %cI64, %t) {} : (!llhd.sig<i64>, i64, !llhd.time) -> ()
-    // CHECK-NEXT: llhd.drv %[[SI64]], %[[CI64]], %[[TIME]], %[[CI1]] : !llhd.sig<i64>, i64, !llhd.time, i1
+    // CHECK-NEXT: llhd.drv %[[SI64]], %[[CI64]] after %[[TIME]] if %[[CI1]] : !llhd.sig<i64>
     "llhd.drv" (%sigI64, %cI64, %t, %cI1) {} : (!llhd.sig<i64>, i64, !llhd.time, i1) -> ()
 
     return
@@ -45,14 +45,14 @@ func @check_drv(%sigI1 : !llhd.sig<i1>, %sigI64 : !llhd.sig<i64>, %cI1 : i1, %cI
 // expected-error @+3 {{failed to verify that type of 'init' and underlying type of 'signal' have to match.}}
 llhd.entity @check_illegal_sig () -> () {
     %cI1 = llhd.const 0 : i1
-    %sig1 = llhd.sig "foo" %cI1 : i1 -> !llhd.sig<i32>
+    %sig1 = "llhd.sig"(%cI1) {name="foo"} : (i1) -> !llhd.sig<i32>
 }
 
 // -----
 
 // expected-error @+2 {{failed to verify that type of 'result' and underlying type of 'signal' have to match.}}
 llhd.entity @check_illegal_prb (%sig : !llhd.sig<i1>) -> () {
-    %prb = llhd.prb %sig : !llhd.sig<i1> -> i32
+    %prb = "llhd.prb"(%sig) {} : (!llhd.sig<i1>) -> i32
 }
 
 // -----
@@ -61,7 +61,7 @@ llhd.entity @check_illegal_prb (%sig : !llhd.sig<i1>) -> () {
 llhd.entity @check_illegal_drv (%sig : !llhd.sig<i1>) -> () {
     %c = llhd.const 0 : i32
     %time = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    llhd.drv %sig, %c, %time : !llhd.sig<i1>, i32, !llhd.time
+    "llhd.drv"(%sig, %c, %time) {} : (!llhd.sig<i1>, i32, !llhd.time) -> ()
 }
 
 // -----
@@ -69,6 +69,6 @@ llhd.entity @check_illegal_drv (%sig : !llhd.sig<i1>) -> () {
 // expected-error @+4 {{Redefinition of signal named 'sigI1'!}}
 llhd.entity @check_unique_sig_names () -> () {
     %cI1 = llhd.const 0 : i1
-    %sig1 = llhd.sig "sigI1" %cI1 : i1 -> !llhd.sig<i1>
-    %sig2 = llhd.sig "sigI1" %cI1 : i1 -> !llhd.sig<i1>
+    %sig1 = llhd.sig "sigI1" %cI1 : i1
+    %sig2 = llhd.sig "sigI1" %cI1 : i1
 }

--- a/test/LLHDToLLVM/convert_signals.mlir
+++ b/test/LLHDToLLVM/convert_signals.mlir
@@ -12,16 +12,16 @@ llhd.entity @sig_conversions () -> () {
     // CHECK-NEXT: %[[GEP_SIG:.*]] = llvm.getelementptr %[[ADDR1]][%[[C1]], %[[C1]]] : (!llvm<"[6 x i8]*">, !llvm.i64, !llvm.i64) -> !llvm<"i8*">
     // CHECK-NEXT: %[[ZEXT0:.*]] = llvm.zext %[[CI1]] : !llvm.i1 to !llvm.i32
     // CHECK-NEXT: %[[SIG:.*]] = llvm.call @alloc_signal(%[[STATE]], %[[GEP_SIG]], %[[GEPENTITY]], %[[ZEXT0]]) : (!llvm<"i8*">, !llvm<"i8*">, !llvm<"i8*">, !llvm.i32) -> !llvm.i32
-    %0 = llhd.sig "sigI1" %init1 : i1 -> !llhd.sig<i1>
+    %0 = llhd.sig "sigI1" %init1 : i1
     // CHECK-NEXT: %[[CALL:.*]] = llvm.call @probe_signal(%[[STATE]], %[[SIG]]) : (!llvm<"i8*">, !llvm.i32) -> !llvm<"i8*">
     // CHECK-NEXT: %[[BC:.*]] = llvm.bitcast %[[CALL]] : !llvm<"i8*"> to !llvm<"i1*">
     // CHECK-NEXT: %[[PRBD:.*]] = llvm.load %[[BC]] : !llvm<"i1*">
-    %1 = llhd.prb %0 : !llhd.sig<i1> -> i1
+    %1 = llhd.prb %0 : !llhd.sig<i1>
     // CHECK-NEXT: %[[TIME:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
     // CHECK-NEXT: %[[DELTA:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
     // CHECK-NEXT: %[[EPS:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
     // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %[[PRBD]] : !llvm.i1 to !llvm.i32
     // CHECK-NEXT: %{{.*}} = llvm.call @drive_signal(%[[STATE]], %[[SIG]], %[[ZEXT1]], %[[TIME]], %[[DELTA]], %[[EPS]]) : (!llvm<"i8*">, !llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32) -> !llvm.void
     %t = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    llhd.drv %0, %1, %t : !llhd.sig<i1>, i1, !llhd.time
+    llhd.drv %0, %1 after %t : !llhd.sig<i1>
 }

--- a/test/LLHDToLLVM/convert_simple.mlir
+++ b/test/LLHDToLLVM/convert_simple.mlir
@@ -25,9 +25,9 @@
 
 llhd.entity @Foo () -> () {
     %0 = llhd.const 0 : i1
-    %toggle = llhd.sig "toggle" %0 : i1 -> !llhd.sig<i1>
-    %1 = llhd.prb %toggle : !llhd.sig<i1> -> i1
+    %toggle = llhd.sig "toggle" %0 : i1
+    %1 = llhd.prb %toggle : !llhd.sig<i1>
     %2 = llhd.not %1 : i1
     %dt = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    llhd.drv %toggle, %2, %dt : !llhd.sig<i1>, i1, !llhd.time
+    llhd.drv %toggle, %2 after %dt : !llhd.sig<i1>
 }

--- a/test/Simulator/sim_simple.mlir
+++ b/test/Simulator/sim_simple.mlir
@@ -12,9 +12,9 @@
 // CHECK-NEXT: 9ns 0d 0e  Foo/toggle  1
 llhd.entity @Foo () -> () {
     %0 = llhd.const 0 : i1
-    %toggle = llhd.sig "toggle" %0 : i1 -> !llhd.sig<i1>
-    %1 = llhd.prb %toggle : !llhd.sig<i1> -> i1
+    %toggle = llhd.sig "toggle" %0 : i1
+    %1 = llhd.prb %toggle : !llhd.sig<i1>
     %2 = llhd.not %1 : i1
     %dt = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    llhd.drv %toggle, %2, %dt : !llhd.sig<i1>, i1, !llhd.time
+    llhd.drv %toggle, %2 after %dt : !llhd.sig<i1>
 }

--- a/test/Target/Verilog/verilog_sig.mlir
+++ b/test/Target/Verilog/verilog_sig.mlir
@@ -8,26 +8,26 @@ llhd.entity @check_sig () -> () {
     %1 = llhd.const 256 : i64
     %2 = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
     // CHECK-NEXT: var _[[C:.*]] = _[[A]];
-    %3 = llhd.sig "sigI1" %0 : i1 -> !llhd.sig<i1>
+    %3 = llhd.sig "sigI1" %0 : i1
     // CHECK-NEXT: var [63:0] _{{.*}} = _[[B]];
-    %4 = llhd.sig "sigI64" %1 : i64 -> !llhd.sig<i64>
-    %5 = llhd.prb %3 : !llhd.sig<i1> -> i1
+    %4 = llhd.sig "sigI64" %1 : i64
+    %5 = llhd.prb %3 : !llhd.sig<i1>
     // CHECK-NEXT: assign _[[C]] = (#1ns) _[[A]];
-    llhd.drv %3, %0, %2 : !llhd.sig<i1>, i1, !llhd.time
+    llhd.drv %3, %0 after %2 : !llhd.sig<i1>
     %6 = llhd.const #llhd.time<0ns, 1d, 0e> : !llhd.time
     // CHECK-NEXT: assign _[[C]] = (#0ns) _[[A]];
-    llhd.drv %3, %0, %6 : !llhd.sig<i1>, i1, !llhd.time
+    llhd.drv %3, %0 after %6 : !llhd.sig<i1>
     // CHECK-NEXT: assign _[[C]] = (#0ns) _[[A]] ? _[[A]] : _[[C]];
-    llhd.drv %3, %0, %6, %0 : !llhd.sig<i1>, i1, !llhd.time, i1
+    llhd.drv %3, %0 after %6 if %0 : !llhd.sig<i1>
 }
 
 // -----
 
 llhd.entity @check_invalid_drv_time () -> () {
     %0 = llhd.const 1 : i1
-    %1 = llhd.sig "sigI1" %0 : i1 -> !llhd.sig<i1>
+    %1 = llhd.sig "sigI1" %0 : i1
     // expected-error @+2 {{Not possible to translate a time attribute with 0 real time and non-1 delta.}}
     // expected-error @+1 {{Operation not supported!}}
     %2 = llhd.const #llhd.time<0ns, 0d, 0e> : !llhd.time
-    llhd.drv %1, %0, %2 : !llhd.sig<i1>, i1, !llhd.time
+    llhd.drv %1, %0 after %2 : !llhd.sig<i1>
 }

--- a/test/Transforms/canonicalization.mlir
+++ b/test/Transforms/canonicalization.mlir
@@ -159,7 +159,7 @@ func @const_hoisting(%sig : !llhd.sig<i32>) {
 ^bb1:
     %0 = llhd.const -1 : i32
     %1 = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    // CHECK-NEXT: llhd.drv %[[SIG]], %[[C0]], %[[TIME]] : !llhd.sig<i32>, i32, !llhd.time
-    llhd.drv %sig, %0, %1 : !llhd.sig<i32>, i32, !llhd.time
+    // CHECK-NEXT: llhd.drv %[[SIG]], %[[C0]] after %[[TIME]] : !llhd.sig<i32>
+    llhd.drv %sig, %0 after %1 : !llhd.sig<i32>
     br ^bb1
 }

--- a/test/Transforms/processLowering.mlir
+++ b/test/Transforms/processLowering.mlir
@@ -30,7 +30,7 @@ llhd.proc @prbAndWait(%arg0 : !llhd.sig<i64>) -> () {
     // CHECK-NEXT: }
     br ^bb1
 ^bb1:
-    %0 = llhd.prb %arg0 : !llhd.sig<i64> -> i64
+    %0 = llhd.prb %arg0 : !llhd.sig<i64>
     llhd.wait %arg0, ^bb1 : !llhd.sig<i64>
 }
 
@@ -41,7 +41,7 @@ llhd.proc @prbAndWaitMoreObserved(%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i64>
     // CHECK-NEXT: }
     br ^bb1
 ^bb1:
-    %0 = llhd.prb %arg0 : !llhd.sig<i64> -> i64
+    %0 = llhd.prb %arg0 : !llhd.sig<i64>
     llhd.wait %arg0, %arg1, ^bb1 : !llhd.sig<i64>, !llhd.sig<i64>
 }
 
@@ -51,7 +51,7 @@ llhd.proc @prbAndWaitMoreObserved(%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i64>
 llhd.proc @prbAndWaitNotObserved(%arg0 : !llhd.sig<i64>) -> () {
     br ^bb1
 ^bb1:
-    %0 = llhd.prb %arg0 : !llhd.sig<i64> -> i64
+    %0 = llhd.prb %arg0 : !llhd.sig<i64>
     // expected-error @+1 {{Process-lowering: The wait terminator is required to have all probed signals as arguments!}}
     llhd.wait ^bb1
 }
@@ -63,7 +63,7 @@ llhd.proc @prbAndWaitNotObserved(%arg0 : !llhd.sig<i64>) -> () {
 llhd.proc @multipleOpsInEntryBlock(%arg0 : !llhd.sig<i64>) -> () {
     %time = llhd.const #llhd.time<0ns, 0d, 0e> : !llhd.time
     %value = llhd.const 42 : i64
-    llhd.drv %arg0, %value, %time : !llhd.sig<i64>, i64, !llhd.time
+    llhd.drv %arg0, %value after %time : !llhd.sig<i64>
     br ^bb1
 ^bb1:
     llhd.wait ^bb1

--- a/test/Transforms/totalFunctionInlining.mlir
+++ b/test/Transforms/totalFunctionInlining.mlir
@@ -31,7 +31,7 @@ llhd.entity @check_entity_inline() -> (%out : !llhd.sig<i32>) {
     // CHECK-NEXT: }
     %1 = call @simple() : () -> i32
     %time = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    llhd.drv %out, %1, %time : !llhd.sig<i32>, i32, !llhd.time
+    llhd.drv %out, %1 after %time : !llhd.sig<i32>
 }
 
 // CHECK-LABEL: @check_proc_inline
@@ -46,12 +46,12 @@ llhd.proc @check_proc_inline(%arg : !llhd.sig<i1>) -> (%out : !llhd.sig<i32>) {
     // CHECK-NEXT: br ^[[BB3]](%[[C1]] : i32)
     // CHECK-NEXT: ^[[BB3]](%[[A:.*]]: i32):
     // CHECK-NEXT: %[[C2:.*]] = llhd.const
-    // CHECK-NEXT: llhd.drv %{{.*}}, %[[A]], %[[C2]] : !llhd.sig<i32>, i32, !llhd.time
+    // CHECK-NEXT: llhd.drv %{{.*}}, %[[A]] after %[[C2]] : !llhd.sig<i32>
     // CHECK-NEXT: llhd.halt
     // CHECK-NEXT: }
-    %0 = llhd.prb %arg : !llhd.sig<i1> -> i1
+    %0 = llhd.prb %arg : !llhd.sig<i1>
     %1 = call @complex(%0) : (i1) -> i32
     %time = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
-    llhd.drv %out, %1, %time : !llhd.sig<i32>, i32, !llhd.time
+    llhd.drv %out, %1 after %time : !llhd.sig<i32>
     llhd.halt
 }


### PR DESCRIPTION
* Previously added TypesMatchWith trait, making the TimeType buildable
and advances in the possibilites of the assemblyFormat allow to make the
syntax of sig, prb and drv less redundant/cluttered
* I followed the syntax of the standard dialect load and store operation
which only annotate the operands type resp. the signal for the drv
* I think there is no point in annotating the time type and the i1 at
the end of the drv operation as they are always the same and just make
it more difficult to read and more work to write by hand
* The 'if' and 'after' keywords in the drv operation should make it more
obvious (easier to identify) which is the time and which the enable
argument