### PR TITLE
Update buildAndTest.yml

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -41,7 +41,7 @@ jobs:
         path: 'llvm'
     - name: Install LLVM
       if: steps.cache-llvm.outputs.cache-hit != 'true'
-      run: mkdir $GITHUB_WORKSPACE/llvm/build && mkdir $GITHUB_WORKSPACE/llvm/install && cd $GITHUB_WORKSPACE/llvm/build && cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON && cmake --build . --target install -- -j$(nproc)
+      run: mkdir $GITHUB_WORKSPACE/llvm/build && mkdir $GITHUB_WORKSPACE/llvm/install && cd $GITHUB_WORKSPACE/llvm/build && cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON && cmake --build . --target install -- -j$(nproc)
     - name: Configure cmake
       run: mkdir $GITHUB_WORKSPACE/llhd/build && cd $GITHUB_WORKSPACE/llhd/build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
     - name: Build and Test LLHD

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -41,11 +41,11 @@ jobs:
         path: 'llvm'
     - name: Install LLVM
       if: steps.cache-llvm.outputs.cache-hit != 'true'
-      run: mkdir llvm/build && mkdir llvm/install && cd llvm/build && cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_LINKER=/usr/bin/lld -DLLVM_PARALLEL_LINK_JOBS=2 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON && cmake --build . --target install
+      run: mkdir $GITHUB_WORKSPACE/llvm/build && mkdir $GITHUB_WORKSPACE/llvm/install && cd $GITHUB_WORKSPACE/llvm/build && cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON && cmake --build . --target install -- -j$(nproc)
     - name: Configure cmake
-      run: mkdir llhd/build && cd llhd/build && cmake $GITHUB_WORKSPACE/llhd -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
+      run: mkdir $GITHUB_WORKSPACE/llhd/build && cd $GITHUB_WORKSPACE/llhd/build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
     - name: Build and Test LLHD
-      run: cd llhd/build && cmake --build . --target check-llhdc
+      run: cmake --build $GITHUB_WORKSPACE/llhd/build --target check-llhdc -- -j$(nproc)
 
   docgen:
     name: Generate Docs
@@ -73,13 +73,14 @@ jobs:
     - name: Generate documentation
       if: steps.cache-llvm.outputs.cache-hit == 'true'
       run: |
-        mkdir llhd/build
-        cd llhd/build
-        cmake $GITHUB_WORKSPACE/llhd -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
+        mkdir $GITHUB_WORKSPACE/llhd/build
+        cd $GITHUB_WORKSPACE/llhd/build
+        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
         cmake --build . --target mlir-doc
     - name: Add doc to target repo
       if: steps.cache-llvm.outputs.cache-hit == 'true'
       run: |
+        cd $GITHUB_WORKSPACE
         cat llhd-docs/assets/templates/opdoc_frontmatter > llhd-docs/docs/LLHDOps.md
         cat llhd/build/docs/Dialect/llhd.md >> llhd-docs/docs/LLHDOps.md
         cat llhd-docs/assets/templates/convdoc_frontmatter > llhd-docs/docs/passes/LLHDToLLVM.md
@@ -89,7 +90,7 @@ jobs:
     - name: Commit and push to target repo
       if: steps.cache-llvm.outputs.cache-hit == 'true'
       run: |
-        cd llhd-docs
+        cd $GITHUB_WORKSPACE/llhd-docs
         git config --local user.name "GitHub Push Action"
         git config --local user.mail "action@generate_docs.com"
         git add docs/LLHDOps.md docs/passes/LLHDToLLVM.md docs/passes/Transformations.md

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -75,8 +75,8 @@ jobs:
       run: |
         mkdir $GITHUB_WORKSPACE/llhd/build
         cd $GITHUB_WORKSPACE/llhd/build
-        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
-        cmake --build . --target mlir-doc
+        cmake $GITHUB_WORKSPACE/llhd -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/
+        cmake --build  $GITHUB_WORKSPACE/llhd/build --target mlir-doc
     - name: Add doc to target repo
       if: steps.cache-llvm.outputs.cache-hit == 'true'
       run: |

--- a/lib/Dialect/LLHD/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/LLHDOps.cpp
@@ -751,6 +751,8 @@ static ParseResult parseRegOp(OpAsmParser &parser, OperationState &result) {
   operandSizes.push_back(gateOperands.size());
   result.addAttribute("operand_segment_sizes",
                       parser.getBuilder().getI32VectorAttr(operandSizes));
+
+  return success();
 }
 
 static void print(OpAsmPrinter &printer, llhd::RegOp op) {

--- a/lib/Dialect/LLHD/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/LLHDOps.cpp
@@ -842,6 +842,7 @@ static LogicalResult verify(llhd::RegOp op) {
       return failure();
     }
   }
+  return success();
 }
 
 #include "Dialect/LLHD/LLHDOpsEnums.cpp.inc"

--- a/lib/Simulator/State.cpp
+++ b/lib/Simulator/State.cpp
@@ -140,6 +140,7 @@ int State::addSignalData(int index, std::string owner, uint8_t *value,
   int globalIdx = instances[owner].signalTable[index];
   signals[globalIdx].detail.value = value;
   signals[globalIdx].size = size;
+  return globalIdx;
 }
 
 void State::dumpSignal(llvm::raw_ostream &out, int index) {


### PR DESCRIPTION
This revision introduces the following changes:
- Drop the CMAKE_LINKER definition when building LLVM, since LLVM_ENABLE_LLD=ON already handles this.
- Don't limit the number of linking jobs and use all available cores when building LLVM.
- Avoid relative directory changes in separate shell contexts to make sure that we are always in the correct location.
- Explicitly build LLHD using clang, drop the unused LLVM_ENABLE_ASSERTIONS definition and use all cores when building.