### PR TITLE
Update lit arguments to show verbose output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ include_directories(${PROJECT_BINARY_DIR}/include)
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
+set(LLVM_LIT_ARGS "-sv" CACHE STRING "lit default options")
+
 # add target for documentation generation
 add_custom_target(llhd-doc)
 


### PR DESCRIPTION
This could make it easier to troubleshoot CI issues related to failing tests, like the issue in #30.