### PR TITLE
Sanitizer build

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -45,10 +45,10 @@ jobs:
     - name: Install LLVM
       if: steps.cache-llvm.outputs.cache-hit != 'true'
       run: mkdir $GITHUB_WORKSPACE/llvm/build && mkdir $GITHUB_WORKSPACE/llvm/install && cd $GITHUB_WORKSPACE/llvm/build && cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON && cmake --build . --target install -- -j$(nproc)
-    - name: Configure cmake
-      run: mkdir $GITHUB_WORKSPACE/llhd/build && cd $GITHUB_WORKSPACE/llhd/build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
-    - name: Build and Test LLHD
-      run: cmake --build $GITHUB_WORKSPACE/llhd/build --target check-llhdc -- -j$(nproc)
+    - name: Sanitizer build
+      run: mkdir $GITHUB_WORKSPACE/llhd/sanitizer-build && cd $GITHUB_WORKSPACE/llhd/sanitizer-build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER='Address;Undefined' -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit && cmake --build $GITHUB_WORKSPACE/llhd/sanitizer-build --target check-llhdc -- -j$(nproc)
+    - name: Release build
+      run: mkdir $GITHUB_WORKSPACE/llhd/build && cd $GITHUB_WORKSPACE/llhd/build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit && cmake --build $GITHUB_WORKSPACE/llhd/build --target check-llhdc -- -j$(nproc)
 
   docgen:
     name: Generate Docs

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -4,9 +4,9 @@ on: [push, pull_request]
 
 env:
   LLVM_COMMIT: 288025494ef460c9c2481039be61cd53116d06ba
-  CMAKE_FLAGS: '-DMLIR_DIR=$GITHUB_WORKSPACE/llvm-project/prefix/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm-project/prefix/lib/cmake/llvm/'
+  CMAKE_FLAGS: '-DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/'
   CMAKE_TOOLCHAIN_FLAGS: '-DCMAKE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
-  CMAKE_LIT_PATH: '-DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm-project/build/bin/llvm-lit'
+  CMAKE_LIT_PATH: '-DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit'
 
 jobs:
   lint:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -44,11 +44,24 @@ jobs:
         path: 'llvm'
     - name: Install LLVM
       if: steps.cache-llvm.outputs.cache-hit != 'true'
-      run: mkdir $GITHUB_WORKSPACE/llvm/build && mkdir $GITHUB_WORKSPACE/llvm/install && cd $GITHUB_WORKSPACE/llvm/build && cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON && cmake --build . --target install -- -j$(nproc)
+      run: |
+        mkdir $GITHUB_WORKSPACE/llvm/build
+        mkdir $GITHUB_WORKSPACE/llvm/install
+        cd $GITHUB_WORKSPACE/llvm/build
+        cmake $GITHUB_WORKSPACE/llvm/llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/llvm/install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+        cmake --build . --target install -- -j$(nproc)
     - name: Sanitizer build
-      run: mkdir $GITHUB_WORKSPACE/llhd/sanitizer-build && cd $GITHUB_WORKSPACE/llhd/sanitizer-build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER='Address;Undefined' -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit && cmake --build $GITHUB_WORKSPACE/llhd/sanitizer-build --target check-llhdc -- -j$(nproc)
+      run: |
+        mkdir $GITHUB_WORKSPACE/llhd/sanitizer-build
+        cd $GITHUB_WORKSPACE/llhd/sanitizer-build
+        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER='Address;Undefined' -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
+        cmake --build . --target check-llhdc -- -j$(nproc)
     - name: Release build
-      run: mkdir $GITHUB_WORKSPACE/llhd/build && cd $GITHUB_WORKSPACE/llhd/build && cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit && cmake --build $GITHUB_WORKSPACE/llhd/build --target check-llhdc -- -j$(nproc)
+      run: |
+        mkdir $GITHUB_WORKSPACE/llhd/build
+        cd $GITHUB_WORKSPACE/llhd/build
+        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
+        cmake --build . --target check-llhdc -- -j$(nproc)
 
   docgen:
     name: Generate Docs
@@ -79,7 +92,7 @@ jobs:
         mkdir $GITHUB_WORKSPACE/llhd/build
         cd $GITHUB_WORKSPACE/llhd/build
         cmake $GITHUB_WORKSPACE/llhd -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/
-        cmake --build  $GITHUB_WORKSPACE/llhd/build --target mlir-doc
+        cmake --build  . --target mlir-doc
     - name: Add doc to target repo
       if: steps.cache-llvm.outputs.cache-hit == 'true'
       run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 env:
   LLVM_COMMIT: 288025494ef460c9c2481039be61cd53116d06ba
+  CMAKE_FLAGS: '-DMLIR_DIR=$GITHUB_WORKSPACE/llvm-project/prefix/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm-project/prefix/lib/cmake/llvm/'
+  CMAKE_TOOLCHAIN_FLAGS: '-DCMAKE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+  CMAKE_LIT_PATH: '-DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm-project/build/bin/llvm-lit'
 
 jobs:
   lint:
@@ -54,13 +57,13 @@ jobs:
       run: |
         mkdir $GITHUB_WORKSPACE/llhd/sanitizer-build
         cd $GITHUB_WORKSPACE/llhd/sanitizer-build
-        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER='Address;Undefined' -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
+        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER='Address;Undefined' ${{ env.CMAKE_FLAGS }} ${{ env.CMAKE_TOOLCHAIN_FLAGS }} ${{ env.CMAKE_LIT_PATH }}
         cmake --build . --target check-llhdc -- -j$(nproc)
     - name: Release build
       run: |
         mkdir $GITHUB_WORKSPACE/llhd/build
         cd $GITHUB_WORKSPACE/llhd/build
-        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release -DCMAKE_LINKER=/usr/bin/lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/ -DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit
+        cmake $GITHUB_WORKSPACE/llhd -DCMAKE_BUILD_TYPE=Release ${{ env.CMAKE_FLAGS }} ${{ env.CMAKE_TOOLCHAIN_FLAGS }} ${{ env.CMAKE_LIT_PATH }}
         cmake --build . --target check-llhdc -- -j$(nproc)
 
   docgen:
@@ -91,7 +94,7 @@ jobs:
       run: |
         mkdir $GITHUB_WORKSPACE/llhd/build
         cd $GITHUB_WORKSPACE/llhd/build
-        cmake $GITHUB_WORKSPACE/llhd -DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/
+        cmake $GITHUB_WORKSPACE/llhd ${{ env.CMAKE_FLAGS }}
         cmake --build  . --target mlir-doc
     - name: Add doc to target repo
       if: steps.cache-llvm.outputs.cache-hit == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ add_definitions(${LLVM_DEFINITIONS})
 
 set(LLVM_LIT_ARGS "-sv" CACHE STRING "lit default options")
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+include(sanitizers)
+
 # add target for documentation generation
 add_custom_target(llhd-doc)
 

--- a/cmake/modules/sanitizers.cmake
+++ b/cmake/modules/sanitizers.cmake
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+set(USE_SANITIZER
+        ""
+        CACHE
+        STRING
+        "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'"
+        )
+
+function(append value)
+    foreach (variable ${ARGN})
+        set(${variable}
+                "${${variable}} ${value}"
+                PARENT_SCOPE)
+    endforeach (variable)
+endfunction()
+
+if (USE_SANITIZER)
+    append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+    if (UNIX)
+
+        if (uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+            append("-O1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+        endif ()
+
+        if (USE_SANITIZER MATCHES "([Aa]ddress);([Uu]ndefined)"
+                OR USE_SANITIZER MATCHES "([Uu]ndefined);([Aa]ddress)")
+            message(STATUS "Building with Address, Undefined sanitizers")
+            append("-fsanitize=address,undefined" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+        elseif (USE_SANITIZER MATCHES "([Aa]ddress)")
+            # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
+            message(STATUS "Building with Address sanitizer")
+            append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+        elseif (USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
+            # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
+            append("-fsanitize=memory" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            if (USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+                message(STATUS "Building with MemoryWithOrigins sanitizer")
+                append("-fsanitize-memory-track-origins" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            else ()
+                message(STATUS "Building with Memory sanitizer")
+            endif ()
+        elseif (USE_SANITIZER MATCHES "([Uu]ndefined)")
+            message(STATUS "Building with Undefined sanitizer")
+            append("-fsanitize=undefined" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            if (EXISTS "${BLACKLIST_FILE}")
+                append("-fsanitize-blacklist=${BLACKLIST_FILE}" CMAKE_C_FLAGS
+                        CMAKE_CXX_FLAGS)
+            endif ()
+        elseif (USE_SANITIZER MATCHES "([Tt]hread)")
+            message(STATUS "Building with Thread sanitizer")
+            append("-fsanitize=thread" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+        elseif (USE_SANITIZER MATCHES "([Ll]eak)")
+            message(STATUS "Building with Leak sanitizer")
+            append("-fsanitize=leak" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+        else ()
+            message(
+                    FATAL_ERROR "Unsupported value of USE_SANITIZER: ${USE_SANITIZER}")
+        endif ()
+    elseif (MSVC)
+        if (USE_SANITIZER MATCHES "([Aa]ddress)")
+            message(STATUS "Building with Address sanitizer")
+            append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+        else ()
+            message(
+                    FATAL_ERROR
+                    "This sanitizer not yet supported in the MSVC environment: ${USE_SANITIZER}"
+            )
+        endif ()
+    else ()
+        message(FATAL_ERROR "USE_SANITIZER is not supported on this platform.")
+    endif ()
+
+endif ()

--- a/cmake/modules/sanitizers.cmake
+++ b/cmake/modules/sanitizers.cmake
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+# Original source: Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+# Modified source: Copyright (C) 2020 by Jean-Michel Gorius
+#                                        - jean-michel.gorius@ens-rennes.fr
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -13,8 +15,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 #
-# Adapted by Jean-Michel Gorius to enable building libraries with sanitizer
-# support.
+# Adapted by Jean-Michel Gorius to forward sanitizer flags to the linker.
 #
 
 set(USE_SANITIZER
@@ -47,30 +48,38 @@ if (USE_SANITIZER)
                 OR USE_SANITIZER MATCHES "([Uu]ndefined);([Aa]ddress)")
             message(STATUS "Building with Address, Undefined sanitizers")
             append("-fsanitize=address,undefined"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Aa]ddress)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
             message(STATUS "Building with Address sanitizer")
             append("-fsanitize=address"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
             append("-fsanitize=memory"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
             if (USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
                 message(STATUS "Building with MemoryWithOrigins sanitizer")
                 append("-fsanitize-memory-track-origins"
-                        CMAKE_C_FLAGS
-                        CMAKE_CXX_FLAGS
+                        CMAKE_EXE_C_FLAGS
+                        CMAKE_EXE_CXX_FLAGS
+                        CMAKE_STATIC_C_FLAGS
+                        CMAKE_STATIC_CXX_FLAGS
                         CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS)
             else ()
@@ -79,29 +88,37 @@ if (USE_SANITIZER)
         elseif (USE_SANITIZER MATCHES "([Uu]ndefined)")
             message(STATUS "Building with Undefined sanitizer")
             append("-fsanitize=undefined"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
             if (EXISTS "${BLACKLIST_FILE}")
                 append("-fsanitize-blacklist=${BLACKLIST_FILE}"
-                        CMAKE_C_FLAGS
-                        CMAKE_CXX_FLAGS
+                        CMAKE_EXE_C_FLAGS
+                        CMAKE_EXE_CXX_FLAGS
+                        CMAKE_STATIC_C_FLAGS
+                        CMAKE_STATIC_CXX_FLAGS
                         CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS)
             endif ()
         elseif (USE_SANITIZER MATCHES "([Tt]hread)")
             message(STATUS "Building with Thread sanitizer")
             append("-fsanitize=thread"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Ll]eak)")
             message(STATUS "Building with Leak sanitizer")
             append("-fsanitize=leak"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
         else ()
@@ -112,8 +129,10 @@ if (USE_SANITIZER)
         if (USE_SANITIZER MATCHES "([Aa]ddress)")
             message(STATUS "Building with Address sanitizer")
             append("-fsanitize=address"
-                    CMAKE_C_FLAGS
-                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_C_FLAGS
+                    CMAKE_EXE_CXX_FLAGS
+                    CMAKE_STATIC_C_FLAGS
+                    CMAKE_STATIC_CXX_FLAGS
                     CMAKE_EXE_LINKER_FLAGS
                     CMAKE_MODULE_LINKER_FLAGS)
         else ()

--- a/cmake/modules/sanitizers.cmake
+++ b/cmake/modules/sanitizers.cmake
@@ -12,6 +12,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
+#
+# Adapted by Jean-Michel Gorius to enable building libraries with sanitizer
+# support.
+#
 
 set(USE_SANITIZER
         ""
@@ -40,33 +44,80 @@ if (USE_SANITIZER)
         if (USE_SANITIZER MATCHES "([Aa]ddress);([Uu]ndefined)"
                 OR USE_SANITIZER MATCHES "([Uu]ndefined);([Aa]ddress)")
             message(STATUS "Building with Address, Undefined sanitizers")
-            append("-fsanitize=address,undefined" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=address,undefined"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Aa]ddress)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
             message(STATUS "Building with Address sanitizer")
-            append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=address"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
-            append("-fsanitize=memory" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=memory"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
             if (USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
                 message(STATUS "Building with MemoryWithOrigins sanitizer")
-                append("-fsanitize-memory-track-origins" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+                append("-fsanitize-memory-track-origins"
+                        CMAKE_C_FLAGS
+                        CMAKE_CXX_FLAGS
+                        CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS
+                        CMAKE_SHARED_LINKER_FLAGS
+                        CMAKE_STATIC_LINKER_FLAGS)
             else ()
                 message(STATUS "Building with Memory sanitizer")
             endif ()
         elseif (USE_SANITIZER MATCHES "([Uu]ndefined)")
             message(STATUS "Building with Undefined sanitizer")
-            append("-fsanitize=undefined" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=undefined"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
             if (EXISTS "${BLACKLIST_FILE}")
-                append("-fsanitize-blacklist=${BLACKLIST_FILE}" CMAKE_C_FLAGS
-                        CMAKE_CXX_FLAGS)
+                append("-fsanitize-blacklist=${BLACKLIST_FILE}"
+                        CMAKE_C_FLAGS
+                        CMAKE_CXX_FLAGS
+                        CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS
+                        CMAKE_SHARED_LINKER_FLAGS
+                        CMAKE_STATIC_LINKER_FLAGS)
             endif ()
         elseif (USE_SANITIZER MATCHES "([Tt]hread)")
             message(STATUS "Building with Thread sanitizer")
-            append("-fsanitize=thread" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=thread"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Ll]eak)")
             message(STATUS "Building with Leak sanitizer")
-            append("-fsanitize=leak" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=leak"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
         else ()
             message(
                     FATAL_ERROR "Unsupported value of USE_SANITIZER: ${USE_SANITIZER}")
@@ -74,7 +125,13 @@ if (USE_SANITIZER)
     elseif (MSVC)
         if (USE_SANITIZER MATCHES "([Aa]ddress)")
             message(STATUS "Building with Address sanitizer")
-            append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+            append("-fsanitize=address"
+                    CMAKE_C_FLAGS
+                    CMAKE_CXX_FLAGS
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS
+                    CMAKE_SHARED_LINKER_FLAGS
+                    CMAKE_STATIC_LINKER_FLAGS)
         else ()
             message(
                     FATAL_ERROR

--- a/cmake/modules/sanitizers.cmake
+++ b/cmake/modules/sanitizers.cmake
@@ -146,3 +146,4 @@ if (USE_SANITIZER)
     endif ()
 
 endif ()
+

--- a/cmake/modules/sanitizers.cmake
+++ b/cmake/modules/sanitizers.cmake
@@ -49,26 +49,30 @@ if (USE_SANITIZER)
             append("-fsanitize=address,undefined"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Aa]ddress)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
             message(STATUS "Building with Address sanitizer")
             append("-fsanitize=address"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
             append("-fsanitize=memory"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
             if (USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
                 message(STATUS "Building with MemoryWithOrigins sanitizer")
                 append("-fsanitize-memory-track-origins"
                         CMAKE_C_FLAGS
                         CMAKE_CXX_FLAGS
-                        CMAKE_SHARED_LINKER_FLAGS)
+                        CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS)
             else ()
                 message(STATUS "Building with Memory sanitizer")
             endif ()
@@ -77,25 +81,29 @@ if (USE_SANITIZER)
             append("-fsanitize=undefined"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
             if (EXISTS "${BLACKLIST_FILE}")
                 append("-fsanitize-blacklist=${BLACKLIST_FILE}"
                         CMAKE_C_FLAGS
                         CMAKE_CXX_FLAGS
-                        CMAKE_SHARED_LINKER_FLAGS)
+                        CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS)
             endif ()
         elseif (USE_SANITIZER MATCHES "([Tt]hread)")
             message(STATUS "Building with Thread sanitizer")
             append("-fsanitize=thread"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Ll]eak)")
             message(STATUS "Building with Leak sanitizer")
             append("-fsanitize=leak"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
         else ()
             message(
                     FATAL_ERROR "Unsupported value of USE_SANITIZER: ${USE_SANITIZER}")
@@ -106,7 +114,8 @@ if (USE_SANITIZER)
             append("-fsanitize=address"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS)
+                    CMAKE_EXE_LINKER_FLAGS
+                    CMAKE_MODULE_LINKER_FLAGS)
         else ()
             message(
                     FATAL_ERROR

--- a/cmake/modules/sanitizers.cmake
+++ b/cmake/modules/sanitizers.cmake
@@ -33,7 +33,9 @@ function(append value)
 endfunction()
 
 if (USE_SANITIZER)
-    append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    append("-fno-omit-frame-pointer"
+            CMAKE_C_FLAGS
+            CMAKE_CXX_FLAGS)
 
     if (UNIX)
 
@@ -47,38 +49,26 @@ if (USE_SANITIZER)
             append("-fsanitize=address,undefined"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Aa]ddress)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
             message(STATUS "Building with Address sanitizer")
             append("-fsanitize=address"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
             # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
             append("-fsanitize=memory"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
             if (USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
                 message(STATUS "Building with MemoryWithOrigins sanitizer")
                 append("-fsanitize-memory-track-origins"
                         CMAKE_C_FLAGS
                         CMAKE_CXX_FLAGS
-                        CMAKE_EXE_LINKER_FLAGS
-                        CMAKE_MODULE_LINKER_FLAGS
-                        CMAKE_SHARED_LINKER_FLAGS
-                        CMAKE_STATIC_LINKER_FLAGS)
+                        CMAKE_SHARED_LINKER_FLAGS)
             else ()
                 message(STATUS "Building with Memory sanitizer")
             endif ()
@@ -87,37 +77,25 @@ if (USE_SANITIZER)
             append("-fsanitize=undefined"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
             if (EXISTS "${BLACKLIST_FILE}")
                 append("-fsanitize-blacklist=${BLACKLIST_FILE}"
                         CMAKE_C_FLAGS
                         CMAKE_CXX_FLAGS
-                        CMAKE_EXE_LINKER_FLAGS
-                        CMAKE_MODULE_LINKER_FLAGS
-                        CMAKE_SHARED_LINKER_FLAGS
-                        CMAKE_STATIC_LINKER_FLAGS)
+                        CMAKE_SHARED_LINKER_FLAGS)
             endif ()
         elseif (USE_SANITIZER MATCHES "([Tt]hread)")
             message(STATUS "Building with Thread sanitizer")
             append("-fsanitize=thread"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
         elseif (USE_SANITIZER MATCHES "([Ll]eak)")
             message(STATUS "Building with Leak sanitizer")
             append("-fsanitize=leak"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
         else ()
             message(
                     FATAL_ERROR "Unsupported value of USE_SANITIZER: ${USE_SANITIZER}")
@@ -128,10 +106,7 @@ if (USE_SANITIZER)
             append("-fsanitize=address"
                     CMAKE_C_FLAGS
                     CMAKE_CXX_FLAGS
-                    CMAKE_EXE_LINKER_FLAGS
-                    CMAKE_MODULE_LINKER_FLAGS
-                    CMAKE_SHARED_LINKER_FLAGS
-                    CMAKE_STATIC_LINKER_FLAGS)
+                    CMAKE_SHARED_LINKER_FLAGS)
         else ()
             message(
                     FATAL_ERROR

--- a/include/Simulator/State.h
+++ b/include/Simulator/State.h
@@ -142,6 +142,9 @@ struct State {
   /// Construct a new empty (at 0 time) state.
   State() = default;
 
+  /// State destructor, ensures all malloc'd signal regions are correctly free'd
+  ~State();
+
   /// Pop the head of the queue and update the simulation time.
   Slot popQueue();
 

--- a/lib/Simulator/CMakeLists.txt
+++ b/lib/Simulator/CMakeLists.txt
@@ -11,7 +11,7 @@ add_mlir_library(LLHDSimState
     LLVMSupport
     )
 
-add_mlir_library(llhd-signals-runtime-wrappers  SHARED
+add_mlir_library(llhd-signals-runtime-wrappers SHARED
     signals-runtime-wrappers.cpp
 
     LINK_LIBS PUBLIC

--- a/lib/Simulator/State.cpp
+++ b/lib/Simulator/State.cpp
@@ -115,6 +115,11 @@ void UpdateQueue::insertOrUpdate(Time time, int index, int bitOffset,
 // State
 //===----------------------------------------------------------------------===//
 
+State::~State() {
+  for (int i = 0; i < nSigs; i++)
+    std::free(signals[i].detail.value);
+}
+
 Slot State::popQueue() {
   assert(!queue.empty() && "the event queue is empty");
   Slot pop = queue.top();


### PR DESCRIPTION
Add support for sanitizer builds and update the CI configuration accordingly. Simplify the CI configuration slightly by centralizing configuration options in the top-level environment and by using multi-line `run` commands.