### PR TITLE
Add tuple instruction

### DIFF
--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -71,6 +71,34 @@ def LLHD_VecOp : LLHD_Op<"vec", [NoSideEffect, TypesMatchWith<
     let assemblyFormat = "`[` $values `]` attr-dict `:` type($result)";
 }
 
+def LLHD_TupleOp : LLHD_Op<"tuple", [NoSideEffect, TypesMatchWith<
+        "types of 'values' have to match the type of the corresponding 'result' tuple element",
+        "result", "values",
+        "$_self.cast<TupleType>().getTypes()">
+    ]> {
+
+    let summary = "Create a tuple from a list of values.";
+
+    let description = [{
+        The `llhd.tuple` operation creates a tuple from a list of SSA-values.
+
+        **Examples:**
+
+        ```
+        %c1 = llhd.const 1 : i32
+        %c2 = llhd.const 2 : i2
+        %sig = llhd.sig "sig_name" %c1 : i32
+        %vec = constant dense<[1, 2]> : vector<2xi32>
+        %tuple = llhd.tuple %c1, %c2, %vec, %sig : tuple<i32, i2, vector<2xi32>, !llhd.sig<i32>>
+        ```
+    }];
+
+    let arguments = (ins Variadic<AnyType>:$values);
+    let results = (outs AnyTuple:$result);
+
+    let assemblyFormat = "$values attr-dict `:` type($result)";
+}
+
 def LLHD_ExtsOp : LLHD_Op<"exts"> {
     let summary = "Extract a slice of consecutive elements.";
 

--- a/test/Dialect/LLHD/tuple.mlir
+++ b/test/Dialect/LLHD/tuple.mlir
@@ -1,0 +1,22 @@
+// RUN: llhdc %s -mlir-print-op-generic -split-input-file -verify-diagnostics | llhdc | llhdc | FileCheck %s
+
+// CHECK-LABEL: @check_tuple
+// CHECK-SAME: %[[C1:.*]]: i1
+// CHECK-SAME: %[[C2:.*]]: i2
+// CHECK-SAME: %[[C3:.*]]: i3
+// CHECK-SAME: %[[VEC:.*]]: vector<3xi32>
+// CHECK-SAME: %[[TUP:.*]]: tuple<i8, i32, i16>
+func @check_tuple(%c1 : i1, %c2 : i2, %c3 : i3, %vec : vector<3xi32>, %tup : tuple<i8, i32, i16>) {
+    // CHECK-NEXT: %{{.*}} = llhd.tuple : tuple<>
+    %0 = llhd.tuple : tuple<>
+    // CHECK-NEXT: %{{.*}} = llhd.tuple %[[C1]] : tuple<i1>
+    %1 = llhd.tuple %c1 : tuple<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.tuple %[[C1]], %[[C2]], %[[C3]] : tuple<i1, i2, i3>
+    %2 = llhd.tuple %c1, %c2, %c3 : tuple<i1, i2, i3>
+    // CHECK-NEXT: %{{.*}} = llhd.tuple %[[C1]], %[[VEC]], %[[TUP]] : tuple<i1, vector<3xi32>, tuple<i8, i32, i16>
+    %3 = llhd.tuple %c1, %vec, %tup : tuple<i1, vector<3xi32>, tuple<i8, i32, i16>>
+
+    return
+}
+
+// TODO: add verification tests


### PR DESCRIPTION
Add simple instruction to create a tuple from a list of ssa-values
This should be the replacement for the struct construction instruction in the rust implementation of LLHD.

Feedback on the syntax and other suggestions are very welcome!