### PR TITLE
add dexts operation

### DIFF
--- a/include/Dialect/LLHD/LLHDBase.td
+++ b/include/Dialect/LLHD/LLHDBase.td
@@ -80,5 +80,15 @@ class LLHD_ArithmeticOrBitwiseOp<string mnemonic, list<OpTrait> traits = []> :
     }];
 }
 
+//===----------------------------------------------------------------------===//
+// LLHD trait definitions
+//===----------------------------------------------------------------------===//
+
+class SameTypeArbitraryWidth<string desc, string lhs, string rhs> : PredOpTrait<desc,
+    CPred<"[&](){ Type lhsType=" # lhs # ".getType(); Type rhsType=" # rhs #
+        ".getType(); return (lhsType.getKind() == rhsType.getKind()) &&" #
+        "(!lhsType.isa<ShapedType>() || (lhsType.cast<ShapedType>().getElementType() == rhsType.cast<ShapedType>().getElementType()));}()">>;
+
+
 
 #endif // LLHD_BASE

--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -106,12 +106,10 @@ def LLHD_ExtsOp : LLHD_Op<"exts"> {
 }
 
 def LLHD_DextsOp : LLHD_Op<"dexts", [NoSideEffect,
-         PredOpTrait<"the target operand and result kinds have to match",
-            CPred<"$target.getType().getKind() == $result.getType().getKind()">>,
+         SameTypeArbitraryWidth<"'target' and 'result' types have to match apart from their width",
+            "$target", "$result">,
          PredOpTrait<"the result width cannot be larger than the target operand width",
-            CPred<"this->getTargetWidth() >= this->getSliceWidth()">>,
-         PredOpTrait<"the vector element types have to match",
-            CPred<"this->getSliceVectorElementTypeOrNull() == this->getTargetVectorElementTypeOrNull()">>
+            CPred<"this->getTargetWidth() >= this->getSliceWidth()">>
         ]> {
     let summary = "Dynamically extract a slice of consecutive elements";
 
@@ -140,12 +138,7 @@ def LLHD_DextsOp : LLHD_Op<"dexts", [NoSideEffect,
 
     let extraClassDeclaration = [{
         unsigned getSliceWidth();
-
         unsigned getTargetWidth();
-
-        Type getSliceVectorElementTypeOrNull();
-
-        Type getTargetVectorElementTypeOrNull();
     }];
 }
 

--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -106,6 +106,36 @@ def LLHD_ExtsOp : LLHD_Op<"exts"> {
     let verifier = [{ return ::verify(*this); }];
 }
 
+def LLHD_DextsOp : LLHD_Op<"dexts"> {
+    let summary = "Dynamically extract a slice of consecutive elements";
+
+    let description = [{
+        The `llhd.dexts` operation allows to dynamically access a slice of the
+        `$target` operand, starting at the index given by the `$start` operand.
+        The resulting slice length is defined by the result type.
+        The `$target` operand kind has to match the result kind.
+        If `$target` is a vector, only the number of elements can change, while
+        the element type has to remain the same.
+
+        **Examples:**
+        ```
+        %0 = llhd.const 0x0f0 : i12
+        %1 = llhd.const 4 : i3
+
+        %3 = llhd.dexts %0, %1 : (i12, i3) -> i4    // %3: 0xf
+
+        ```
+    }];
+
+    let arguments = (ins AnyTypeOf<[AnySignlessInteger, AnyVector, LLHD_AnySigType]>: $target,
+                         AnySignlessInteger: $start);
+    let results = (outs AnyTypeOf<[AnySignlessInteger, AnyVector, LLHD_AnySigType]>: $result);
+
+    let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
+
+    let verifier = [{ return ::verify(*this); }];
+}
+
 //===----------------------------------------------------------------------===//
 //=== Signal Operations
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -106,7 +106,14 @@ def LLHD_ExtsOp : LLHD_Op<"exts"> {
     let verifier = [{ return ::verify(*this); }];
 }
 
-def LLHD_DextsOp : LLHD_Op<"dexts"> {
+def LLHD_DextsOp : LLHD_Op<"dexts", [NoSideEffect,
+         PredOpTrait<"the target operand and result kinds have to match",
+            CPred<"$target.getType().getKind() == $result.getType().getKind()">>,
+         PredOpTrait<"the result width cannot be larger than the target operand width",
+            CPred<"this->getTargetWidth() >= this->getSliceWidth()">>,
+         PredOpTrait<"the vector element types have to match",
+            CPred<"this->getSliceVectorElementTypeOrNull() == this->getTargetVectorElementTypeOrNull()">>
+        ]> {
     let summary = "Dynamically extract a slice of consecutive elements";
 
     let description = [{
@@ -133,7 +140,15 @@ def LLHD_DextsOp : LLHD_Op<"dexts"> {
 
     let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 
-    let verifier = [{ return ::verify(*this); }];
+    let extraClassDeclaration = [{
+        unsigned getSliceWidth();
+
+        unsigned getTargetWidth();
+
+        Type getSliceVectorElementTypeOrNull();
+
+        Type getTargetVectorElementTypeOrNull();
+    }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -129,7 +129,6 @@ def LLHD_DextsOp : LLHD_Op<"dexts", [NoSideEffect,
         %1 = llhd.const 4 : i3
 
         %3 = llhd.dexts %0, %1 : (i12, i3) -> i4    // %3: 0xf
-
         ```
     }];
 

--- a/include/Dialect/LLHD/LLHDOps.td
+++ b/include/Dialect/LLHD/LLHDOps.td
@@ -90,7 +90,6 @@ def LLHD_ExtsOp : LLHD_Op<"exts"> {
         %2 = llhd.sig %0 : i32
         %3 = llhd.exts %2, 0, 5 : !llhd.sig<i32> to !llhd.sig<i5>
         ```
-
     }];
 
     let arguments = (ins AnyTypeOf<[AnySignlessInteger, LLHD_AnySigType]>: $target,

--- a/lib/Dialect/LLHD/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/LLHDOps.cpp
@@ -118,18 +118,6 @@ unsigned llhd::DextsOp::getTargetWidth() {
   return 0;
 }
 
-Type llhd::DextsOp::getSliceVectorElementTypeOrNull() {
-  if (auto vecTy = result().getType().dyn_cast<VectorType>())
-    return vecTy.getElementType();
-  return NULL;
-}
-
-Type llhd::DextsOp::getTargetVectorElementTypeOrNull() {
-  if (auto vecTy = target().getType().dyn_cast<VectorType>())
-    return vecTy.getElementType();
-  return NULL;
-}
-
 //===----------------------------------------------------------------------===//
 // NegOp
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/LLHD/ext.mlir
+++ b/test/Dialect/LLHD/ext.mlir
@@ -114,7 +114,7 @@ func @illegal_out_too_big(%c : i32) {
 // -----
 
 func @dexts_illegal_conversion(%s : !llhd.sig<i32>, %i : i1) {
-    // expected-error @+1 {{the target and result kinds have to match}}
+    // expected-error @+1 {{'llhd.dexts' op failed to verify that the target operand and result kinds have to match}}
     %0 = llhd.dexts %s, %i : (!llhd.sig<i32>, i1) -> i10
 
     return
@@ -123,7 +123,7 @@ func @dexts_illegal_conversion(%s : !llhd.sig<i32>, %i : i1) {
 // -----
 
 func @dexts_illegal_out_too_wide(%c : i32, %i : i1) {
-    // expected-error @+1 {{the result width cannot be larger than the target width}}
+    // expected-error @+1 {{'llhd.dexts' op failed to verify that the result width cannot be larger than the target operand width}}
     %0 = llhd.dexts %c, %i : (i32, i1) -> i40
 
     return
@@ -132,7 +132,7 @@ func @dexts_illegal_out_too_wide(%c : i32, %i : i1) {
 // -----
 
 func @dexts_illegal_vec_element_conversion(%c : vector<1xi1>, %i : i1) {
-    // expected-error @+1 {{vector element type conversion is not allowed, expected 'i1' but got 'i10'}}
+    // expected-error @+1 {{'llhd.dexts' op failed to verify that the vector element types have to match}}
     %0 = llhd.dexts %c, %i : (vector<1xi1>, i1) -> vector<1xi10>
 
     return

--- a/test/Dialect/LLHD/ext.mlir
+++ b/test/Dialect/LLHD/ext.mlir
@@ -24,6 +24,48 @@ func @exts_signals (%sI1 : !llhd.sig<i1>, %sI32 : !llhd.sig<i32>) -> () {
     return
 }
 
+// CHECK-LABEL: @dexts_integers
+// CHECK-SAME: %[[CI1:.*]]: i1,
+// CHECK-SAME: %[[CI32:.*]]: i32,
+// CHECK-SAME: %[[IND0:.*]]: i5,
+// CHECK-SAME: %[[IND1:.*]]: i10
+func @dexts_integers(%cI1 : i1, %cI32 : i32, %i0 : i5, %i1 : i10) {
+    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[CI1]], %[[IND0]] : (i1, i5) -> i1
+    %0 = llhd.dexts %cI1, %i0 : (i1, i5) -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[CI32]], %[[IND1]] : (i32, i10) -> i15
+    %1 = llhd.dexts %cI32, %i1 : (i32, i10) -> i15
+
+    return
+}
+
+// CHECK-LABEL: @dexts_signals
+// CHECK-SAME: %[[SI1:.*]]: !llhd.sig<i1>,
+// CHECK-SAME: %[[SI32:.*]]: !llhd.sig<i32>,
+// CHECK-SAME: %[[IND0:.*]]: i5,
+// CHECK-SAME: %[[IND1:.*]]: i10
+func @dexts_signals (%sI1 : !llhd.sig<i1>, %sI32 : !llhd.sig<i32>, %i0 : i5, %i1 : i10) {
+    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI1]], %[[IND0]] : (!llhd.sig<i1>, i5) -> !llhd.sig<i1>
+    %0 = llhd.dexts %sI1, %i0 : (!llhd.sig<i1>, i5) -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI32]], %[[IND1]] : (!llhd.sig<i32>, i10) -> !llhd.sig<i5>
+    %1 = llhd.dexts %sI32, %i1 : (!llhd.sig<i32>, i10) -> !llhd.sig<i5>
+
+    return
+}
+
+// CHECK-LABEL: @dexts_vec
+// CHECK-SAME: %[[V1:.*]]: vector<1xi1>,
+// CHECK-SAME: %[[V10:.*]]: vector<10xi1>,
+// CHECK-SAME: %[[IND0:.*]]: i5,
+// CHECK-SAME: %[[IND1:.*]]: i10
+func @dexts_vec(%v1 : vector<1xi1>, %v10 : vector<10xi1>, %i0 : i5, %i1 : i10) {
+    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[V1]], %[[IND0]] : (vector<1xi1>, i5) -> vector<1xi1>
+    %0 = llhd.dexts %v1, %i0 : (vector<1xi1>, i5) -> vector<1xi1>
+    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[V10]], %[[IND1]] : (vector<10xi1>, i10) -> vector<5xi1>
+    %1 = llhd.dexts %v10, %i1 : (vector<10xi1>, i10) -> vector<5xi1>
+
+    return
+}
+
 // -----
 
 func @illegal_int_to_sig(%c : i32) {
@@ -65,6 +107,33 @@ func @illegal_out_sig_width(%s : !llhd.sig<i32>) {
 func @illegal_out_too_big(%c : i32) {
     // expected-error @+1 {{the result bit width cannot be larger than the target width}}
     %0 = llhd.exts %c, 0, 40 : i32 to i40
+
+    return
+}
+
+// -----
+
+func @dexts_illegal_conversion(%s : !llhd.sig<i32>, %i : i1) {
+    // expected-error @+1 {{the target and result kinds have to match}}
+    %0 = llhd.dexts %s, %i : (!llhd.sig<i32>, i1) -> i10
+
+    return
+}
+
+// -----
+
+func @dexts_illegal_out_too_wide(%c : i32, %i : i1) {
+    // expected-error @+1 {{the result width cannot be larger than the target width}}
+    %0 = llhd.dexts %c, %i : (i32, i1) -> i40
+
+    return
+}
+
+// -----
+
+func @dexts_illegal_vec_element_conversion(%c : vector<1xi1>, %i : i1) {
+    // expected-error @+1 {{vector element type conversion is not allowed, expected 'i1' but got 'i10'}}
+    %0 = llhd.dexts %c, %i : (vector<1xi1>, i1) -> vector<1xi10>
 
     return
 }

--- a/test/Dialect/LLHD/ext.mlir
+++ b/test/Dialect/LLHD/ext.mlir
@@ -114,7 +114,7 @@ func @illegal_out_too_big(%c : i32) {
 // -----
 
 func @dexts_illegal_conversion(%s : !llhd.sig<i32>, %i : i1) {
-    // expected-error @+1 {{'llhd.dexts' op failed to verify that the target operand and result kinds have to match}}
+    // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
     %0 = llhd.dexts %s, %i : (!llhd.sig<i32>, i1) -> i10
 
     return
@@ -132,7 +132,7 @@ func @dexts_illegal_out_too_wide(%c : i32, %i : i1) {
 // -----
 
 func @dexts_illegal_vec_element_conversion(%c : vector<1xi1>, %i : i1) {
-    // expected-error @+1 {{'llhd.dexts' op failed to verify that the vector element types have to match}}
+    // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
     %0 = llhd.dexts %c, %i : (vector<1xi1>, i1) -> vector<1xi10>
 
     return


### PR DESCRIPTION
* the supported types are integers, vectors and signals
* the verifier checks for type conversions and result length not being larger than the input
