### PR TITLE
run docgen job only when pushing on master

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -70,6 +70,7 @@ jobs:
     name: Generate Docs
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
     - name: Cache LLVM
       id: cache-llvm


### PR DESCRIPTION
* this should avoid having failing docgen builds when a PR and branch run try to push docs at the same time
* also, this avoids overwriting the current docs with potentially uncompleted docs or docs from experimental operations