### PR TITLE
Compiler warnings in the simulator

### DIFF
--- a/lib/Dialect/LLHD/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/LLHDOps.cpp
@@ -346,8 +346,8 @@ static void printArgumentList(OpAsmPrinter &printer,
 
 static void print(OpAsmPrinter &printer, llhd::EntityOp op) {
   std::vector<BlockArgument> ins, outs;
-  int64_t n_ins = op.insAttr().getInt();
-  for (int64_t i = 0; i < op.body().front().getArguments().size(); ++i) {
+  uint64_t n_ins = op.insAttr().getInt();
+  for (uint64_t i = 0; i < op.body().front().getArguments().size(); ++i) {
     // no furter verification for the attribute type is required, already
     // handled by verify.
     if (i < n_ins) {
@@ -372,12 +372,12 @@ static void print(OpAsmPrinter &printer, llhd::EntityOp op) {
 }
 
 static LogicalResult verify(llhd::EntityOp op) {
-  Block &body = op.body().front();
-  int64_t nIns = op.insAttr().getInt();
+  uint64_t numArgs = op.getNumArguments();
+  uint64_t nIns = op.insAttr().getInt();
   // check that there is at most one flag for each argument
-  if (body.getArguments().size() < nIns) {
+  if (numArgs < nIns) {
     op.emitError("Cannot have more inputs than arguments, expected at most ")
-        << body.getArguments().size() << " but got: " << nIns;
+        << numArgs << " but got: " << nIns;
     return failure();
   }
   return success();

--- a/lib/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/LLHDToLLVM/LLHDToLLVM.cpp
@@ -56,8 +56,7 @@ LLVM::LLVMFuncOp getOrInsertFunction(ModuleOp &module,
     if (insertBodyAndTerminator) {
       func.addEntryBlock();
       OpBuilder b(func.getBody());
-      auto ret =
-          b.create<LLVM::ReturnOp>(rewriter.getUnknownLoc(), ValueRange());
+      b.create<LLVM::ReturnOp>(rewriter.getUnknownLoc(), ValueRange());
     }
   }
   return func;
@@ -137,7 +136,7 @@ struct EntityOpConversion : public ConvertToLLVMPattern {
     // add state, signal table and arguments table arguments
     intermediate.addInputs(
         ArrayRef<Type>({i8PtrTy, i32Ty.getPointerTo(), i32Ty.getPointerTo()}));
-    for (int i = 0; i < entityOp.getNumArguments(); i++)
+    for (unsigned i = 0; i < entityOp.getNumArguments(); i++)
       intermediate.addInputs(i, voidTy);
     rewriter.applySignatureConversion(&entityOp.getBody(), intermediate);
 
@@ -149,7 +148,7 @@ struct EntityOpConversion : public ConvertToLLVMPattern {
     final.addInputs(1, i32Ty.getPointerTo());
     final.addInputs(2, i32Ty.getPointerTo());
 
-    for (int i = 0; i < entityOp.getNumArguments(); i++) {
+    for (unsigned i = 0; i < entityOp.getNumArguments(); i++) {
       // create gep and load operations from arguments table for each original
       // argument
       auto index = bodyBuilder.create<LLVM::ConstantOp>(
@@ -305,8 +304,8 @@ struct InstOpConversion : public ConvertToLLVMPattern {
                   .cast<LLVM::LLVMType>()
                   .getPointerTo(),
               mall);
-          auto initStore = initBuilder.create<LLVM::StoreOp>(
-              rewriter.getUnknownLoc(), initDef, bitcast);
+          initBuilder.create<LLVM::StoreOp>(rewriter.getUnknownLoc(), initDef,
+                                            bitcast);
           Value initStatePtr = initFunc.getArgument(0);
           llvm::SmallVector<Value, 5> args(
               {initStatePtr, indexConst, owner, mall, sizeConst});
@@ -345,16 +344,10 @@ struct SigOpConversion : public ConvertToLLVMPattern {
     // get adapted opreands
     OperandAdaptor<SigOp> transformed(operands);
     // get sig operation
-    auto sigOp = cast<SigOp>(op);
     // get parent module
-    auto module = op->getParentOfType<ModuleOp>();
 
     // collect llvm types
-    auto voidTy = getVoidType();
-    auto i8PtrTy = getVoidPtrType();
-    auto i1Ty = LLVM::LLVMType::getIntNTy(typeConverter.getDialect(), 1);
     auto i32Ty = LLVM::LLVMType::getInt32Ty(typeConverter.getDialect());
-    auto i64Ty = LLVM::LLVMType::getInt64Ty(typeConverter.getDialect());
 
     //! load the signal's index from the signal table
     // get signal table argument
@@ -394,10 +387,6 @@ struct PrbOpConversion : public ConvertToLLVMPattern {
     auto module = op->getParentOfType<ModuleOp>();
 
     // collect llvm types
-    auto voidTy = getVoidType();
-    auto i8PtrTy = getVoidPtrType();
-    auto i32Ty = LLVM::LLVMType::getInt32Ty(typeConverter.getDialect());
-    auto i64Ty = LLVM::LLVMType::getInt64Ty(typeConverter.getDialect());
     auto finalTy =
         typeConverter.convertType(prbOp.getType()).cast<LLVM::LLVMType>();
 
@@ -460,7 +449,6 @@ struct DrvOpConversion : public ConvertToLLVMPattern {
     // collect used llvm types
     auto voidTy = getVoidType();
     auto i8PtrTy = getVoidPtrType();
-    auto i1Ty = LLVM::LLVMType::getIntNTy(typeConverter.getDialect(), 1);
     auto i32Ty = LLVM::LLVMType::getInt32Ty(typeConverter.getDialect());
     auto i64Ty = LLVM::LLVMType::getInt64Ty(typeConverter.getDialect());
 
@@ -806,7 +794,6 @@ struct ExtsOpConversion : public ConvertToLLVMPattern {
     auto i8PtrTy = getVoidPtrType();
     auto i32Ty = LLVM::LLVMType::getInt32Ty(&getDialect());
     auto i64Ty = LLVM::LLVMType::getInt64Ty(&getDialect());
-    auto sigTy = LLVM::LLVMType::getStructTy(&getDialect(), {i8PtrTy, i64Ty});
 
     // get attributes as constants
     auto startConst = rewriter.create<LLVM::ConstantOp>(op->getLoc(), indexTy,
@@ -909,7 +896,6 @@ void llhd::populateLLHDToLLVMConversionPatterns(
 }
 
 void LLHDToLLVMLoweringPass::runOnOperation() {
-  auto module = getOperation();
   OwningRewritePatternList patterns;
   auto converter = mlir::LLVMTypeConverter(&getContext());
 

--- a/lib/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/LLHDToLLVM/LLHDToLLVM.cpp
@@ -343,8 +343,6 @@ struct SigOpConversion : public ConvertToLLVMPattern {
                   ConversionPatternRewriter &rewriter) const override {
     // get adapted opreands
     OperandAdaptor<SigOp> transformed(operands);
-    // get sig operation
-    // get parent module
 
     // collect llvm types
     auto i32Ty = LLVM::LLVMType::getInt32Ty(typeConverter.getDialect());

--- a/lib/Simulator/Engine.cpp
+++ b/lib/Simulator/Engine.cpp
@@ -182,7 +182,7 @@ void Engine::buildLayout(ModuleOp module) {
 }
 
 void Engine::walkEntity(EntityOp entity, Instance &child) {
-  auto res = entity.walk([&](Operation *op) -> WalkResult {
+  entity.walk([&](Operation *op) -> WalkResult {
     assert(op);
 
     //! add signal to signal table
@@ -205,7 +205,7 @@ void Engine::walkEntity(EntityOp entity, Instance &child) {
         for (auto arg : inst.inputs()) {
           // check if the argument comes from a parent's argument
           if (auto a = arg.dyn_cast<BlockArgument>()) {
-            int argInd = a.getArgNumber();
+            unsigned int argInd = a.getArgNumber();
             // the argument comes either from one of the inputs or one of the
             // outputs
             if (argInd < newChild.sensitivityList.size())
@@ -231,7 +231,7 @@ void Engine::walkEntity(EntityOp entity, Instance &child) {
         for (auto out : inst.outputs()) {
           // check if comes from arg
           if (auto a = out.dyn_cast<BlockArgument>()) {
-            int argInd = a.getArgNumber();
+            unsigned int argInd = a.getArgNumber();
             // the argument comes either from one of the inputs or one of the
             // outputs
             if (argInd < newChild.sensitivityList.size())

--- a/lib/Simulator/Engine.cpp
+++ b/lib/Simulator/Engine.cpp
@@ -35,7 +35,10 @@ Engine::Engine(llvm::raw_ostream &out, OwningModuleRef &module,
 
   mlir::PassManager pm(&context);
   pm.addPass(llhd::createConvertLLHDToLLVMPass());
-  pm.run(*module);
+  if (failed(pm.run(*module))) {
+    llvm::errs() << "failed to convert module to LLVM";
+    exit(EXIT_FAILURE);
+  }
 
   this->module = *module;
 

--- a/lib/Simulator/State.cpp
+++ b/lib/Simulator/State.cpp
@@ -58,7 +58,7 @@ Signal::Signal(int origin, uint8_t *value, uint64_t size, uint64_t offset)
 bool Signal::operator==(const Signal &rhs) const {
   if (owner != rhs.owner || name != rhs.name || size != rhs.size)
     return false;
-  for (int i = 0; i < size; i++) {
+  for (uint64_t i = 0; i < size; i++) {
     if (detail.value[i] != rhs.detail.value[i])
       return false;
   }
@@ -100,7 +100,7 @@ void Slot::insertChange(int index, int bitOffset, APInt &bytes) {
 //===----------------------------------------------------------------------===//
 void UpdateQueue::insertOrUpdate(Time time, int index, int bitOffset,
                                  APInt &bytes) {
-  for (int i = 0; i < c.size(); i++) {
+  for (unsigned long i = 0; i < c.size(); i++) {
     if (time == c[i].time) {
       c[i].insertChange(index, bitOffset, bytes);
       return;
@@ -199,7 +199,7 @@ void State::dumpLayout() {
 
 void State::dumpSignalTriggers() {
   llvm::errs() << "::------------- Signal information -------------::\n";
-  for (int i = 0; i < signals.size(); i++) {
+  for (unsigned long i = 0; i < signals.size(); i++) {
     llvm::errs() << signals[i].owner << "/" << signals[i].name
                  << " triggers: " << signals[i].owner << " ";
     for (auto trig : signals[i].triggers) {

--- a/lib/Simulator/signals-runtime-wrappers.cpp
+++ b/lib/Simulator/signals-runtime-wrappers.cpp
@@ -25,7 +25,7 @@ int alloc_signal(State *state, int index, char *owner, uint8_t *value,
 int gather_signal(State *state, char *name, char *owner) {
   assert(state && "gather_signal: state not found");
   std::string sName(name), sOwner(owner);
-  for (int i = 0; i < state->signals.size(); i++) {
+  for (unsigned long i = 0; i < state->signals.size(); i++) {
     if (state->signals[i].name == sName && state->signals[i].owner == sOwner)
       return i;
   }


### PR DESCRIPTION
There are a lot of unused variables and comparisons of integers with
differend signedness in the simulator, the compiler complains about.

Those are probably unintended, so this PR should remove most of them.