### PR TITLE
update ci

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on: [push, pull_request]
 
 env:
-  LLVM_COMMIT: ff9c1ae213a2ed6a760659a30f8399ffd56dc9b0
+  LLVM_COMMIT: fb9f9dc318d62788885a122aaee9dcd4272e87b1
   CMAKE_FLAGS: '-DMLIR_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/mlir/ -DLLVM_DIR=$GITHUB_WORKSPACE/llvm/install/lib/cmake/llvm/'
   CMAKE_TOOLCHAIN_FLAGS: '-DCMAKE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
   CMAKE_LIT_PATH: '-DLLVM_EXTERNAL_LIT=$GITHUB_WORKSPACE/llvm/build/bin/llvm-lit'

--- a/lib/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/LLHDToLLVM/LLHDToLLVM.cpp
@@ -120,7 +120,7 @@ struct EntityOpConversion : public ConvertToLLVMPattern {
     // reset signal counter
     signalCounter = 0;
     // get adapted operands
-    OperandAdaptor<EntityOp> transformed(operands);
+    EntityOpAdaptor transformed(operands);
     // get entity operation
     auto entityOp = cast<EntityOp>(op);
 
@@ -342,7 +342,7 @@ struct SigOpConversion : public ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     // get adapted opreands
-    OperandAdaptor<SigOp> transformed(operands);
+    SigOpAdaptor transformed(operands);
 
     // collect llvm types
     auto i32Ty = LLVM::LLVMType::getInt32Ty(typeConverter.getDialect());
@@ -378,7 +378,7 @@ struct PrbOpConversion : public ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     // get adapted operands
-    OperandAdaptor<PrbOp> transformed(operands);
+    PrbOpAdaptor transformed(operands);
     // get probe operation
     auto prbOp = cast<PrbOp>(op);
     // get parent module
@@ -438,7 +438,7 @@ struct DrvOpConversion : public ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     // get adapted operands;
-    OperandAdaptor<DrvOp> transformed(operands);
+    DrvOpAdaptor transformed(operands);
     // get drive operation
     auto drvOp = cast<DrvOp>(op);
     // get parent module
@@ -535,7 +535,7 @@ struct NotOpConversion : public ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     // get adapted operands
-    OperandAdaptor<NotOp> transformed(operands);
+    NotOpAdaptor transformed(operands);
     // get `llhd.not` operation
     auto notOp = cast<NotOp>(op);
     // get integer width
@@ -571,7 +571,7 @@ struct ShrOpConversion : public ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
 
-    OperandAdaptor<ShrOp> transformed(operands);
+    ShrOpAdaptor transformed(operands);
     auto shrOp = cast<ShrOp>(op);
 
     if (auto resTy = shrOp.result().getType().dyn_cast<IntegerType>()) {
@@ -686,7 +686,7 @@ struct ShlOpConversion : public ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
 
-    OperandAdaptor<ShlOp> transformed(operands);
+    ShlOpAdaptor transformed(operands);
     auto shlOp = cast<ShlOp>(op);
     assert(!(shlOp.getType().getKind() == llhd::LLHDTypes::Sig) &&
            "sig not yet supported");
@@ -786,7 +786,7 @@ struct ExtsOpConversion : public ConvertToLLVMPattern {
                   ConversionPatternRewriter &rewriter) const override {
     auto extsOp = cast<ExtsOp>(op);
 
-    OperandAdaptor<ExtsOp> transformed(operands);
+    ExtsOpAdaptor transformed(operands);
 
     auto indexTy = typeConverter.convertType(extsOp.startAttr().getType());
     auto i8PtrTy = getVoidPtrType();
@@ -904,8 +904,7 @@ void LLHDToLLVMLoweringPass::runOnOperation() {
   target.addIllegalOp<InstOp>();
 
   // apply partial conversion
-  if (failed(
-          applyPartialConversion(getOperation(), target, patterns, &converter)))
+  if (failed(applyPartialConversion(getOperation(), target, patterns)))
     signalPassFailure();
 
   // setup full conversion
@@ -916,7 +915,7 @@ void LLHDToLLVMLoweringPass::runOnOperation() {
   target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
 
   // apply full conversion
-  if (failed(applyFullConversion(getOperation(), target, patterns, &converter)))
+  if (failed(applyFullConversion(getOperation(), target, patterns)))
     signalPassFailure();
 }
 


### PR DESCRIPTION
* rename OperandAdaptors according to [this commit](https://github.com/llvm/llvm-project/commit/2d2c73c5cfdedf55f6e1a8ae7f59ee54e2d89c99#diff-3b0113c00b84d049fc0158245e6bdf31)'s changes
* remove type converter argument from apply-conversion calls (according to [this commit](https://github.com/llvm/llvm-project/commit/8d67d187ba1bdb201f83ce25725e9be59b0141a7#diff-c8f01ab0fec5f0b3426d305fcdb87a03))