### PR TITLE
Trigger an assertion when trying to print an unknown type or attribute

### DIFF
--- a/lib/Dialect/LLHD/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/LLHDDialect.cpp
@@ -119,7 +119,7 @@ void LLHDDialect::printType(Type type, DialectAsmPrinter &printer) const {
   }
 
   default:
-    break;
+    llvm_unreachable("unknown LLHD type");
   }
 }
 
@@ -195,7 +195,7 @@ void LLHDDialect::printAttribute(Attribute attr,
     break;
   }
   default:
-    break;
+    llvm_unreachable("unknown LLHD attribute");
   }
 }
 


### PR DESCRIPTION
This helps to catch unhandled types and attributes.